### PR TITLE
Prevent `dim` and `bold` modifiers from canceling each other

### DIFF
--- a/src/reduce.ts
+++ b/src/reduce.ts
@@ -23,10 +23,20 @@ export function reduceAnsiCodesIncremental(codes: AnsiCode[], newCodes: AnsiCode
 			// Special case: Intensity codes (1m, 2m) can coexist (both end with 22m).
 			const isIntensityCode =
 				code.code === ansiStyles.bold.open || code.code === ansiStyles.dim.open;
-			if (!isIntensityCode) {
+
+			// Add intensity codes only if not already present
+			if (isIntensityCode) {
+				if (
+					!ret.find(
+						(retCode) => retCode.code === code.code && retCode.endCode === code.endCode,
+					)
+				) {
+					ret.push(code);
+				}
+			} else {
 				ret = ret.filter((retCode) => retCode.endCode !== code.endCode);
+				ret.push(code);
 			}
-			ret.push(code);
 		}
 	}
 	return ret;

--- a/test/reduce.ts
+++ b/test/reduce.ts
@@ -182,6 +182,103 @@ test("dim + bold are both preserved", (t) => {
 	t.is(JSON.stringify(reduced), JSON.stringify(codes));
 });
 
+test("dim + bold do not stack infinitely", (t) => {
+	const codes: AnsiCode[] = [
+		{
+			type: "ansi",
+			code: ansiStyles.dim.open,
+			endCode: ansiStyles.dim.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.bold.open,
+			endCode: ansiStyles.bold.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.dim.open,
+			endCode: ansiStyles.dim.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.bold.open,
+			endCode: ansiStyles.bold.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.dim.open,
+			endCode: ansiStyles.dim.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.bold.open,
+			endCode: ansiStyles.bold.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.dim.open,
+			endCode: ansiStyles.dim.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.bold.open,
+			endCode: ansiStyles.bold.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.dim.open,
+			endCode: ansiStyles.dim.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.bold.open,
+			endCode: ansiStyles.bold.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.dim.open,
+			endCode: ansiStyles.dim.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.bold.open,
+			endCode: ansiStyles.bold.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.bold.open,
+			endCode: ansiStyles.bold.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.bold.open,
+			endCode: ansiStyles.bold.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.bold.open,
+			endCode: ansiStyles.bold.close,
+		},
+	];
+
+	const expected: AnsiCode[] = [
+		{
+			type: "ansi",
+			code: ansiStyles.dim.open,
+			endCode: ansiStyles.dim.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.bold.open,
+			endCode: ansiStyles.bold.close,
+		},
+	];
+
+	const reduced = reduceAnsiCodes(codes);
+	t.is(reduced.length, 2);
+	t.is(JSON.stringify(reduced), JSON.stringify(expected));
+});
+
 test("dim + bold are both closed at the same time", (t) => {
 	const codes: AnsiCode[] = [
 		{


### PR DESCRIPTION
**Problem:** `bold` and `dim` modifiers have the same endCode `[22m`. The reduce procedure cancels out one when another is present.

**Solution:** special-case `bold` and `dim`.

**Notes:** first commit adds failing test, last commit fixes the test.