### PR TITLE
fix: parse compound SGR sequences

### DIFF
--- a/src/ansiCodes.ts
+++ b/src/ansiCodes.ts
@@ -2,6 +2,8 @@ import ansiStyles from "ansi-styles";
 import type { AnsiCode } from "./tokenize.js";
 
 export const ESCAPES = new Set([27, 155]); // \x1b and \x9b
+export const CSI = "[".codePointAt(0)!;
+export const OSC = "]".codePointAt(0)!;
 
 export const endCodesSet = new Set<string>();
 const endCodesMap = new Map<string, string>();

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -1,9 +1,11 @@
 import isFullwidthCodePoint from "is-fullwidth-code-point";
 import {
+	CSI,
 	ESCAPES,
 	getEndCode,
 	linkStartCodePrefix,
 	linkStartCodePrefixCharCodes,
+	OSC,
 } from "./ansiCodes.js";
 
 export interface AnsiCode {
@@ -20,17 +22,7 @@ export interface Char {
 
 export type Token = AnsiCode | Char;
 
-function findNumberIndex(str: string): number {
-	for (let index = 0; index < str.length; index++) {
-		const charCode = str.charCodeAt(index);
-		if (charCode >= 48 && charCode <= 57) {
-			return index;
-		}
-	}
-
-	return -1;
-}
-
+// HOT PATH: Use only basic string/char code operations for maximum performance
 function parseLinkCode(string: string, offset: number): string | undefined {
 	string = string.slice(offset);
 	for (let index = 1; index < linkStartCodePrefixCharCodes.length; index++) {
@@ -45,17 +37,77 @@ function parseLinkCode(string: string, offset: number): string | undefined {
 	return string.slice(0, endIndex + 1);
 }
 
-function parseAnsiCode(string: string, offset: number): string | undefined {
-	string = string.slice(offset, offset + 19);
-	const startIndex = findNumberIndex(string);
-	if (startIndex !== -1) {
-		let endIndex = string.indexOf("m", startIndex);
-		if (endIndex === -1) {
-			endIndex = string.length;
+const CC_0 = "0".charCodeAt(0);
+const CC_9 = "9".charCodeAt(0);
+const CC_SEMI = ";".charCodeAt(0);
+const CC_M = "m".charCodeAt(0);
+
+/**
+ * Scans through the given string and finds the index of the last character of an SGR sequence
+ * like `\x1B[38;2;123;123;123m`. This assumes that the string has been checked to start with `\x1B[`.
+ * Returns -1 if no valid SGR sequence is found.
+ */
+function findSGRSequenceEndIndex(str: string): number {
+	for (let index = 2; index < str.length; index++) {
+		const charCode = str.charCodeAt(index);
+		// m marks the end of the SGR sequence
+		if (charCode === CC_M) return index;
+		// Digits and semicolons are valid
+		if (charCode === CC_SEMI) continue;
+		if (charCode >= CC_0 && charCode <= CC_9) continue;
+		// Everything else is invalid
+		break;
+	}
+
+	return -1;
+}
+
+// HOT PATH: Use only basic string/char code operations for maximum performance
+function parseSGRSequence(string: string, offset: number): string | undefined {
+	string = string.slice(offset);
+	const endIndex = findSGRSequenceEndIndex(string);
+	if (endIndex === -1) return;
+
+	return string.slice(0, endIndex + 1);
+}
+
+/**
+ * Splits compound SGR sequences like `\x1B[1;3;31m` into individual components
+ */
+function splitCompoundSGRSequences(code: string): string[] {
+	if (!code.includes(";")) {
+		// Not a compound code
+		return [code];
+	}
+
+	const codeParts = code
+		// Strip off the escape sequences \x1B[ and m
+		.slice(2, -1)
+		.split(";");
+
+	const ret: string[] = [];
+	for (let i = 0; i < codeParts.length; i++) {
+		const rawCode = codeParts[i];
+		// Keep 8-bit and 24-bit color codes (containing multiple ";") together
+		if (rawCode === "38" || rawCode === "48") {
+			if (i + 2 < codeParts.length && codeParts[i + 1] === "5") {
+				// 8-bit color, followed by another number
+				ret.push(codeParts.slice(i, i + 3).join(";"));
+				i += 2;
+				continue;
+			} else if (i + 4 < codeParts.length && codeParts[i + 1] === "2") {
+				// 24-bit color, followed by three numbers
+				ret.push(codeParts.slice(i, i + 5).join(";"));
+				i += 4;
+				continue;
+			}
 		}
 
-		return string.slice(0, endIndex + 1);
+		// Not a (valid) 8/24-bit color code, push as is
+		ret.push(rawCode);
 	}
+
+	return ret.map((part) => `\x1b[${part}m`);
 }
 
 export function tokenize(str: string, endChar: number = Number.POSITIVE_INFINITY): Token[] {
@@ -67,14 +119,37 @@ export function tokenize(str: string, endChar: number = Number.POSITIVE_INFINITY
 		const codePoint = str.codePointAt(index)!;
 
 		if (ESCAPES.has(codePoint)) {
-			// TODO: We should probably decide on the next character ("[" or "]") which code path to take.
-			const code = parseLinkCode(str, index) || parseAnsiCode(str, index);
+			let code: string | undefined;
+
+			// Peek the next code point to determine the type of ANSI sequence
+			const nextCodePoint = str.codePointAt(index + 1);
+			if (nextCodePoint === OSC) {
+				// ] = operating system commands, like links
+				code = parseLinkCode(str, index);
+				if (code) {
+					ret.push({
+						type: "ansi",
+						code: code,
+						endCode: getEndCode(code),
+					});
+				}
+			} else if (nextCodePoint === CSI) {
+				// [ = control sequence introducer, like SGR sequences [...m
+				code = parseSGRSequence(str, index);
+				if (code) {
+					// Split compound codes into individual tokens
+					const codes = splitCompoundSGRSequences(code);
+					for (const individualCode of codes) {
+						ret.push({
+							type: "ansi",
+							code: individualCode,
+							endCode: getEndCode(individualCode),
+						});
+					}
+				}
+			}
+
 			if (code) {
-				ret.push({
-					type: "ansi",
-					code,
-					endCode: getEndCode(code),
-				});
 				index += code.length;
 				continue;
 			}

--- a/test/tokenize.ts
+++ b/test/tokenize.ts
@@ -292,3 +292,55 @@ test("correctly detects emojis as full-width", () => {
 
 	expect(JSON.stringify(tokens, null, 4)).toBe(JSON.stringify(expected, null, 4));
 });
+
+test("splits compound ANSI codes with multiple attributes into individual tokens", () => {
+	// bold + some 24-bit color + underline + green
+	const str = "\x1b[1;38;2;12;23;34;4;32mbaz\x1b[0m";
+	debugger;
+	const tokens = tokenize(str);
+
+	const expected = [
+		{
+			type: "ansi",
+			code: ansiStyles.bold.open,
+			endCode: ansiStyles.bold.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.color.ansi16m(12, 23, 34),
+			endCode: ansiStyles.color.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.underline.open,
+			endCode: ansiStyles.underline.close,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.green.open,
+			endCode: ansiStyles.green.close,
+		},
+		{
+			type: "char",
+			value: "b",
+			fullWidth: false,
+		},
+		{
+			type: "char",
+			value: "a",
+			fullWidth: false,
+		},
+		{
+			type: "char",
+			value: "z",
+			fullWidth: false,
+		},
+		{
+			type: "ansi",
+			code: ansiStyles.reset.open,
+			endCode: ansiStyles.reset.close,
+		},
+	];
+
+	expect(JSON.stringify(tokens, null, 4)).toBe(JSON.stringify(expected, null, 4));
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
 	test: {
 		globals: false,
 		include: ["test/**/*.ts"],
+		watch: false,
 	},
 });


### PR DESCRIPTION
This PR fixes several flaws in our parsing routines for SGR sequences. Previously, it accepted invalid SGR sequences without the final `m`, and failed to parse compound SGR sequences that could be longer than 19 characters.

When parsing SGR sequences, we now scan forward, possibly until the end of the string until we find either the end of it, or an invalid character.
Compound SGR sequences, like `\x1B[1;31m` (bold+red) are now tokenized into two separate codes, so the reducer is able to cancel them individually.

fixes: #36 