### PR TITLE
feat: support OSC 8 hyperlinks with parameters

### DIFF
--- a/src/ansiCodes.ts
+++ b/src/ansiCodes.ts
@@ -12,20 +12,19 @@ for (const [start, end] of ansiStyles.codes) {
 	endCodesMap.set(ansiStyles.color.ansi(start), ansiStyles.color.ansi(end));
 }
 
-export const linkStartCodePrefix = "\x1B]8;;";
-export const linkDetectionPrefix = "\x1B]8;"; // OSC 8 without the second semicolon, for detecting links with params
-export const linkStartCodePrefixCharCodes = linkStartCodePrefix
-	.split("")
-	.map((char) => char.charCodeAt(0));
-export const linkDetectionPrefixCharCodes = linkDetectionPrefix
-	.split("")
-	.map((char) => char.charCodeAt(0));
+export const linkCodePrefix = "\x1B]8;"; // OSC 8 link prefix (params and URL follow)
+export const linkCodePrefixCharCodes = linkCodePrefix.split("").map((char) => char.charCodeAt(0));
 export const linkCodeSuffix = "\x07";
 export const linkCodeSuffixCharCode = linkCodeSuffix.charCodeAt(0);
 export const linkEndCode = `\x1B]8;;${linkCodeSuffix}`;
 
-export function getLinkStartCode(url: string): string {
-	return `${linkStartCodePrefix}${url}${linkCodeSuffix}`;
+export function getLinkStartCode(url: string, params?: Record<string, string>): string {
+	const paramsStr = params
+		? Object.entries(params)
+				.map(([k, v]) => `${k}=${v}`)
+				.join(":")
+		: "";
+	return `${linkCodePrefix}${paramsStr};${url}${linkCodeSuffix}`;
 }
 
 export function getEndCode(code: string): string {
@@ -34,7 +33,7 @@ export function getEndCode(code: string): string {
 
 	// We have a few special cases to handle here:
 	// Links:
-	if (code.startsWith(linkDetectionPrefix)) return linkEndCode;
+	if (code.startsWith(linkCodePrefix)) return linkEndCode;
 
 	code = code.slice(2);
 

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -3,8 +3,8 @@ import {
 	CSI,
 	ESCAPES,
 	getEndCode,
-	linkDetectionPrefix,
-	linkDetectionPrefixCharCodes,
+	linkCodePrefix,
+	linkCodePrefixCharCodes,
 	OSC,
 } from "./ansiCodes.js";
 
@@ -25,13 +25,13 @@ export type Token = AnsiCode | Char;
 // HOT PATH: Use only basic string/char code operations for maximum performance
 function parseLinkCode(string: string, offset: number): string | undefined {
 	string = string.slice(offset);
-	for (let index = 1; index < linkDetectionPrefixCharCodes.length; index++) {
-		if (string.charCodeAt(index) !== linkDetectionPrefixCharCodes[index]) {
+	for (let index = 1; index < linkCodePrefixCharCodes.length; index++) {
+		if (string.charCodeAt(index) !== linkCodePrefixCharCodes[index]) {
 			return undefined;
 		}
 	}
 	// Find the semicolon that ends params
-	const paramsEndIndex = string.indexOf(";", linkDetectionPrefix.length);
+	const paramsEndIndex = string.indexOf(";", linkCodePrefix.length);
 	if (paramsEndIndex === -1) return undefined;
 	// This is a link code (with or without the URL part). Find the end of it.
 	const endIndex = string.indexOf("\x07", paramsEndIndex + 1);

--- a/test/tokenize.ts
+++ b/test/tokenize.ts
@@ -1,5 +1,6 @@
 import ansiStyles from "ansi-styles";
 import { expect, test } from "vitest";
+import { getLinkStartCode } from "../src/ansiCodes.js";
 import { tokenize } from "../src/tokenize.js";
 
 test("splits unformatted strings into characters", () => {
@@ -386,6 +387,21 @@ test("supports links with semicolons in URL", () => {
 	];
 
 	expect(JSON.stringify(tokens, null, 4)).toBe(JSON.stringify(expected, null, 4));
+});
+
+test("getLinkStartCode generates link without params", () => {
+	const code = getLinkStartCode("https://example.com");
+	expect(code).toBe("\x1B]8;;https://example.com\x07");
+});
+
+test("getLinkStartCode generates link with single param", () => {
+	const code = getLinkStartCode("https://example.com", { id: "link1" });
+	expect(code).toBe("\x1B]8;id=link1;https://example.com\x07");
+});
+
+test("getLinkStartCode generates link with multiple params", () => {
+	const code = getLinkStartCode("https://example.com", { id: "foo", line: "42" });
+	expect(code).toBe("\x1B]8;id=foo:line=42;https://example.com\x07");
 });
 
 test("correctly detects emojis as full-width", () => {


### PR DESCRIPTION
## Summary

- Adds support for OSC 8 hyperlinks with parameters (e.g., `ESC]8;id=1;url BEL`)
- Previously only empty-param links (`ESC]8;;url`) were recognized
- Links with params like `id=foo` or `id=foo:line=42` were incorrectly treated as plain text

The `id` parameter enables independent hover underlining across terminal lines.  Params are described in this [OSC 8 hyperlinks gist](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) (adopted by iTerm2 and many other terminal emulators).

## Problem
I was having issues with `ink` not rendering links correctly.  For the same hyperlink, it will hover over all repeats of it.  An  "id=" param was needed to differentiate them.  However, the param is not handled, so it renders terribly.

Examples before:
* without `id=`:
![without_id](https://github.com/user-attachments/assets/c03c2080-7aae-4015-b36e-45b3e9757eb9)


* with `id=`:
<img width="535" height="173" alt="Screenshot 2026-01-22 at 7 50 14 PM" src="https://github.com/user-attachments/assets/c4ff7829-5ab6-4da7-9811-f3a84149df97" />

## Changes

- `src/ansiCodes.ts`: Added `linkDetectionPrefix` constant, relaxed link detection to match any `ESC]8;` prefix
- `src/tokenize.ts`: Updated `parseLinkCode()` to find params-ending semicolon before the URL
- `test/tokenize.ts`: Added tests for parameterized links, multiple colon-separated params, and URLs containing semicolons

## Test plan
Unit tests & manually tested in `ink` that repeated links hover independently.
![ansi-tokenizer-fix](https://github.com/user-attachments/assets/bbd8303f-985b-4102-a826-2bcfce398fa2)


- [x] All existing tests pass
- [x] New test: links with single parameter (`id=1`)
- [x] New test: links with multiple colon-separated parameters (`id=foo:line=42`)
- [x] New test: URLs containing semicolons

🤖 Generated with [Claude Code](https://claude.ai/code)